### PR TITLE
Keep unbound from answering external requests

### DIFF
--- a/board/freescale/ls1046a-rdb/rootfs_overlay/etc/unbound/unbound.conf
+++ b/board/freescale/ls1046a-rdb/rootfs_overlay/etc/unbound/unbound.conf
@@ -51,7 +51,7 @@ server:
 	# specify 0.0.0.0 and ::0 to bind to all available interfaces.
 	# specify every interface[@port] on a new 'interface:' labelled line.
 	# The listen interfaces are not changed on reload, only on restart.
-	interface: 0.0.0.0
+	interface: 10.0.10.1
 	# interface: 192.0.2.153
 	# interface: 192.0.2.154
 	# interface: 192.0.2.154@5003


### PR DESCRIPTION
This change tells unbound to only listen on the IPv4 address of the LAN (eth1) interface.
This will keep it from participating in a DNS amplification attack initiated by an outside attacker.
Unbound should only reply to requests coming from one of it's downstream networks.