### PR TITLE
Feat: Adding Docker Build Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+images/
+buildroot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:24.04 AS base
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    git \
+    autoconf \
+    bison \
+    flex \
+    texinfo \
+    help2man \
+    gawk \
+    libtool-bin \
+    libncurses5-dev \
+    unzip \
+    libbpf-dev \
+    libmount-dev \
+    fdisk \
+    curl \
+    gcc \
+    g++ \
+    gperf \
+    make \
+    python3-dev \
+    automake \
+    libtool \
+    wget \
+    bzip2 \
+    xz-utils \
+    patch \
+    libstdc++6 \
+    rsync \
+    cpio \
+    bc
+
+RUN mkdir -p /opt/x-tools && \
+    chown -R ubuntu:ubuntu /opt/x-tools
+
+USER ubuntu
+FROM base AS xtools
+
+RUN git clone https://github.com/crosstool-ng/crosstool-ng /home/ubuntu/crosstool-ng && \
+    cd /home/ubuntu/crosstool-ng && \
+    git checkout crosstool-ng-1.26.0 && \
+    ./bootstrap && \
+    ./configure --enable-local && \
+    make -j`nproc`
+
+ADD ./configs/crosstool-ng-1.26.0_defconfig /home/ubuntu/mono_filesystem/configs/crosstool-ng-1.26.0_defconfig
+
+RUN cd /home/ubuntu/crosstool-ng && \
+    DEFCONFIG=../mono_filesystem/configs/crosstool-ng-1.26.0_defconfig ./ct-ng defconfig && \
+    ./ct-ng build -j`nproc`
+
+FROM base AS rootfs
+
+WORKDIR /home/ubuntu/buildroot
+COPY --from=xtools /opt/x-tools /opt/x-tools
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+USER root
+RUN chown -R ubuntu:ubuntu /home/ubuntu && \
+    chmod +x /docker-entrypoint.sh
+
+USER ubuntu
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ This image has two interfaces:
 - `eth0`, which doesn't have an IP configured and is meant as the WAN
 - `eth1`, which has a static IP of 10.0.10.1 and is meant as LAN and has DHCP server bound to it
 
+### Using Docker
+First, make sure to have docker installed. Then run the below build command to prep the environment. Then use the docker run command to get into a persistent build environment for buildroot. First runs will always take a long time, but subsequent builds will be faster.
+
+```console
+docker build -t mono-linux .
+docker run --rm -it -v $PWD:/home/ubuntu/mono_filesystem mono-linux <command>
+```
+
 **TODO:** Make the interfaces more freely configurable
 
 If you have the LS1046A-RDB (or any other arm64 board should work, but we haven't tested any, yet), you can test this filesystem by mounting it through NFS; First, create a directory that you'll share with the network (modify IP and directory name as needed).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#### TODO: This File Needs Hardening And Cleaning Up.
+
+MONOROUTER_DIR="/home/ubuntu/mono_filesystem"
+BUILDROOT_DIR="$MONOROUTER_DIR/buildroot"
+
+if [ -z "$(ls -A $BUILDROOT_DIR)" ]; then
+    echo "The directory $BUILDROOT_DIR not found. Cloning into Buildroot"
+    git clone https://github.com/buildroot/buildroot $BUILDROOT_DIR && \
+    cd $BUILDROOT_DIR && \
+    git checkout 2024.05
+else
+    # echo "The directory $BUILDROOT_DIR is not empty. Skipping clone operation."
+    cd $BUILDROOT_DIR
+fi
+
+initConfig() {
+    make BR2_EXTERNAL=$MONOROUTER_DIR ls1046a-rdb_defconfig
+}
+
+buildRoot() {
+    make -j`nproc`
+    cp -r $BUILDROOT_DIR/output/images/* $MONOROUTER_DIR/image
+}
+
+# Main script logic
+case "$1" in
+    buildRoot)
+        buildRoot
+        ;;
+    initConfig)
+        initConfig
+        ;;
+    shell)
+        /bin/bash
+        ;;
+    *)
+        echo "Invalid argument. Use 'initConfig' or 'buildRoot'."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This is a slow pass to add support for building the rootfs using docker containers. This still needs more work, but for now, it's an easy bootstrap for newcomers that want to build out the images.